### PR TITLE
Fixes Bazzite image build by using `sh`

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -150,10 +150,10 @@ func (m *Bazzite) Build(
 
 	container = container.
 		WithExec([]string{
-			"echo",
-			"'import? \"/usr/share/ublue-os/just/99-lily.just\"'",
-			">>",
-			"/usr/share/ublue-os/justfile"}).
+			"sh",
+			"-c",
+			"echo 'import? \"/usr/share/ublue-os/just/99-lily.just\"' | tee -a /usr/share/ublue-os/justfile",
+		}).
 		WithExec([]string{"bootc", "container", "lint"})
 
 	return container


### PR DESCRIPTION
Addresses an issue where the Bazzite image build process was failing.

- Uses `sh -c` and `tee` to correctly append the lily.just import statement to the justfile.
- This ensures the import statement is properly added, resolving the build failure.