### PR TITLE
Adds COSMIC desktop support

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -183,6 +183,8 @@ func (m *Bazzite) BazziteContainer(
 			"openrgb",
 			"podman-docker",
 			"warp-terminal",
+			"@cosmic-desktop",
+			"@cosmic-desktop-apps",
 		}).
 		WithOptFix(ctx, "warpdotdev", "warp-terminal", "warp-terminal/warp").
 		WithServices(ctx, []string{


### PR DESCRIPTION
Adds support for the COSMIC desktop environment.

- Enables the use of COSMIC desktop by adding `@cosmic-desktop` and `@cosmic-desktop-apps` to the list of supported features.